### PR TITLE
Refactor summary methods for HTML support and consistency

### DIFF
--- a/pyproforma/models/results.py
+++ b/pyproforma/models/results.py
@@ -501,14 +501,14 @@ class CategoryResults:
         Return HTML representation for Jupyter notebooks.
         This ensures proper formatting when the object is displayed in a notebook cell.
         """
-        summary_text = self.summary()
-        # Convert newlines to HTML line breaks for proper notebook display
-        html_summary = summary_text.replace('\n', '<br>')
-        return f'<pre>{html_summary}</pre>'
+        return self.summary(html=True)
 
-    def summary(self) -> str:
+    def summary(self, html: bool = False) -> str:
         """
         Return a summary string with key statistics about the category.
+        
+        Args:
+            html (bool, optional): If True, returns HTML formatted output. Defaults to False.
         
         Returns:
             str: Formatted summary of the category
@@ -516,20 +516,29 @@ class CategoryResults:
         num_items = len(self.line_items_definitions)
         item_names = [item.name for item in self.line_items_definitions]
         
-        # Get total for first year if category includes total
+        # Get totals for all years if category includes totals
         total_info = ""
         if self.category_obj.include_total and self.model.years:
-            first_year = self.model.years[0]
             try:
-                total_value = self.model.category_total(self.category_name, first_year)
-                total_info = f"\nTotal ({first_year}): {total_value:,.0f}"
+                totals_list = []
+                for year in self.model.years:
+                    total_value = self.model.category_total(self.category_name, year)
+                    formatted_total = f"{total_value:,.0f}"
+                    totals_list.append(formatted_total)
+                total_info = f"\nTotals: {', '.join(totals_list)}"
             except (KeyError, AttributeError):
-                total_info = "\nTotal: Not available"
+                total_info = "\nTotals: Not available"
         
-        return (f"CategoryResults('{self.category_name}')\n"
+        summary_text = (f"CategoryResults('{self.category_name}')\n"
                 f"Label: {self.category_obj.label}\n"
                 f"Line Items: {num_items}\n"
                 f"Items: {', '.join(item_names)}{total_info}")
+        
+        if html:
+            html_summary = summary_text.replace('\n', '<br>')
+            return f'<pre>{html_summary}</pre>'
+        else:
+            return summary_text
 
 
 class ConstraintResults:

--- a/pyproforma/models/results.py
+++ b/pyproforma/models/results.py
@@ -146,9 +146,7 @@ class LineItemResults:
         Return HTML representation for Jupyter notebooks.
         This ensures proper formatting when the object is displayed in a notebook cell.
         """
-        summary_text = self.summary()
-        html_summary = summary_text.replace('\n', '<br>')
-        return f'<pre>{html_summary}</pre>'
+        return self.summary(html=True)
     
     def percent_change(self, year: int) -> float:
         """
@@ -338,23 +336,28 @@ class LineItemResults:
         
         return cumulative_sum
 
-    def summary(self) -> str:
+    def summary(self, html: bool = False) -> str:
         """
         Return a summary string with key information about the line item.
+        
+        Args:
+            html (bool, optional): If True, returns HTML formatted output. Defaults to False.
         
         Returns:
             str: Formatted summary of the line item
         """
-        # Get value for first year if available
+        # Get values for all years as a list
         value_info = ""
         if self.model.years:
-            first_year = self.model.years[0]
             try:
-                value = self.model.value(self.item_name, first_year)
-                formatted_value = format_value(value, self.value_format)
-                value_info = f"\nValue ({first_year}): {formatted_value}"
+                values_list = []
+                for year in self.model.years:
+                    value = self.model.value(self.item_name, year)
+                    formatted_value = format_value(value, self.value_format)
+                    values_list.append(formatted_value)
+                value_info = f"\nValues: {', '.join(values_list)}"
             except KeyError:
-                value_info = "\nValue: Not available"
+                value_info = "\nValues: Not available"
         
         # Get formula information based on source type
         formula_info = ""
@@ -370,10 +373,16 @@ class LineItemResults:
         elif self.source_type == "category":
             formula_info = f"\nFormula: Sum of items in category '{self.item_name}'"
         
-        return (f"LineItemResults('{self.item_name}')\n"
+        summary_text = (f"LineItemResults('{self.item_name}')\n"
                 f"Label: {self.label}\n"
                 f"Source Type: {self.source_type}\n"
                 f"Value Format: {self.value_format}{formula_info}{value_info}")
+        
+        if html:
+            html_summary = summary_text.replace('\n', '<br>')
+            return f'<pre>{html_summary}</pre>'
+        else:
+            return summary_text
 
 
 class CategoryResults:

--- a/tests/models/results/test_category_results.py
+++ b/tests/models/results/test_category_results.py
@@ -126,7 +126,7 @@ class TestCategoryResultsStringRepresentation:
         assert "Label: Income" in str_result
         assert "Line Items: 2" in str_result
         assert "Items: product_sales, service_revenue" in str_result
-        assert "Total (2023):" in str_result
+        assert "Totals:" in str_result
         
     def test_repr_method(self, category_results_with_total):
         """Test __repr__ method returns expected format."""
@@ -142,7 +142,7 @@ class TestCategoryResultsStringRepresentation:
         assert "Label: Income" in summary
         assert "Line Items: 2" in summary
         assert "Items: product_sales, service_revenue" in summary
-        assert "Total (2023): 150,000" in summary
+        assert "Totals: 150,000, 180,000, 210,000" in summary
     
     def test_summary_method_without_total(self, category_results_without_total):
         """Test summary method with category that doesn't include totals."""
@@ -434,7 +434,7 @@ class TestCategoryResultsErrorHandling:
             
             assert "CategoryResults('income')" in summary
             assert "Label: Income" in summary
-            assert "Total: Not available" in summary
+            assert "Totals: Not available" in summary
     
     def test_table_method_with_table_error(self, model_with_categories_basic):
         """Test table method when underlying table method raises error."""
@@ -506,7 +506,7 @@ class TestCategoryResultsIntegration:
         str_result = str(category_results)
         assert "CategoryResults('income')" in str_result
         assert "Label: Income" in str_result
-        assert "Total (2023): 150,000" in str_result
+        assert "Totals: 150,000, 180,000" in str_result
     
     def test_category_results_html_representation_integration(self, integrated_model):
         """Test HTML representation with real model data."""

--- a/tests/models/results/test_line_item_results.py
+++ b/tests/models/results/test_line_item_results.py
@@ -103,7 +103,7 @@ class TestLineItemResultsStringRepresentation:
         assert "Label: Revenue" in str_result
         assert "Source Type: line_item" in str_result
         assert "Value Format: no_decimals" in str_result
-        assert "Value (2023):" in str_result
+        assert "Values:" in str_result
         
     def test_repr_method(self, line_item_results):
         """Test __repr__ method returns expected format."""
@@ -119,7 +119,7 @@ class TestLineItemResultsStringRepresentation:
         assert "Label: Revenue" in summary
         assert "Source Type: line_item" in summary
         assert "Value Format: no_decimals" in summary
-        assert "Value (2023): 100,000" in summary
+        assert "Values: 100,000, 120,000, 140,000" in summary
         assert "Formula: None (explicit values)" in summary
     
     def test_summary_method_with_formula(self, line_item_results_with_formula):
@@ -417,7 +417,7 @@ class TestLineItemResultsErrorHandling:
             
             assert "LineItemResults('revenue')" in summary
             assert "Label: Revenue" in summary
-            assert "Value: Not available" in summary
+            assert "Values: Not available" in summary
     
     def test_chart_method_with_chart_error(self, model_with_line_items_basic):
         """Test chart method when underlying chart method raises error."""
@@ -490,7 +490,7 @@ class TestLineItemResultsIntegration:
         str_result = str(line_item_results)
         assert "LineItemResults('revenue')" in str_result
         assert "Label: Revenue" in str_result
-        assert "Value (2023): 100,000" in str_result
+        assert "Values: 100,000, 120,000" in str_result
     
     def test_line_item_results_html_representation_integration(self, integrated_model):
         """Test HTML representation with real model data."""
@@ -558,7 +558,7 @@ class TestLineItemResultsEdgeCases:
         summary = line_item_results.summary()
         assert "LineItemResults('revenue_2024')" in summary
         assert "Label: Revenue 2024" in summary
-        assert "Value (2024): 100,000" in summary
+        assert "Values: 100,000" in summary
     
     def test_line_item_results_with_single_year(self):
         """Test LineItemResults with model containing only one year."""


### PR DESCRIPTION
Enhance the summary methods in `LineItemResults` and `CategoryResults` to support HTML formatting and return values and totals for all years. Update string representation tests for consistency across both classes.

Fixes #67